### PR TITLE
CAS Global Logout Refactored

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -40,12 +40,14 @@ class Module extends AbstractModule
         $connection = $services->get('Omeka\Connection');
         $connection->exec('CREATE TABLE cas_user (id VARCHAR(255) NOT NULL, user_id INT NOT NULL, INDEX IDX_8DA51140A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
         $connection->exec('ALTER TABLE cas_user ADD CONSTRAINT FK_8DA51140A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $connection->exec('CREATE TABLE cas_ticket (ticket VARCHAR(255) NOT NULL, session_id VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, INDEX IDX_A28BE1D7613FECDF (session_id), PRIMARY KEY(ticket)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
     }
 
     public function uninstall(ServiceLocatorInterface $services)
     {
         $connection = $services->get('Omeka\Connection');
         $connection->exec('DROP TABLE IF EXISTS cas_user');
+        $connection->exec('DROP TABLE IF EXISTS cas_ticket');
     }
 
     public function upgrade($oldVersion, $newVersion, ServiceLocatorInterface $serviceLocator)
@@ -57,6 +59,10 @@ class Module extends AbstractModule
             $connection->exec('ALTER TABLE cas_user DROP INDEX UNIQ_8DA51140A76ED395');
             $connection->exec('ALTER TABLE cas_user ADD INDEX IDX_8DA51140A76ED395 (user_id)');
             $connection->exec('ALTER TABLE cas_user ADD CONSTRAINT FK_8DA51140A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        }
+
+        if (Comparator::lessThan($oldVersion, '0.7.0')) {
+            $connection->exec('CREATE TABLE IF NOT EXISTS cas_ticket (ticket VARCHAR(255) NOT NULL, session_id VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, INDEX IDX_A28BE1D7613FECDF (session_id), PRIMARY KEY(ticket)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
         }
     }
 
@@ -132,6 +138,10 @@ class Module extends AbstractModule
         $acl->allow(
             null,
             'CAS\Controller\Login'
+        );
+        $acl->allow(
+            null, 
+            'CAS\Controller\Slo'
         );
     }
 }

--- a/Module.php
+++ b/Module.php
@@ -92,6 +92,8 @@ class Module extends AbstractModule
             'user_name_attribute' => $settings->get('cas_user_name_attribute'),
             'user_email_attribute' => $settings->get('cas_user_email_attribute'),
             'show_login_link_in_user_bar' => $settings->get('cas_show_login_link_in_user_bar'),
+            'global_logout' => $settings->get('cas_global_logout'),
+            'logout_redirect_service' => $settings->get('cas_logout_redirect_service'),
         ]);
 
         return $renderer->formCollection($form, false);
@@ -116,6 +118,8 @@ class Module extends AbstractModule
         $settings->set('cas_user_name_attribute', $formData['user_name_attribute']);
         $settings->set('cas_user_email_attribute', $formData['user_email_attribute']);
         $settings->set('cas_show_login_link_in_user_bar', $formData['show_login_link_in_user_bar']);
+        $settings->set('cas_global_logout', !empty($formData['global_logout']));
+        $settings->set('cas_logout_redirect_service', trim((string) ($formData['logout_redirect_service'] ?? '')));
 
         return true;
     }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,6 +6,16 @@ return [
     'controllers' => [
         'factories' => [
             'CAS\Controller\Login' => Service\Controller\LoginControllerFactory::class,
+            'CAS\Controller\Slo' => Service\Controller\SloControllerFactory::class,
+        ],
+    ],
+    'listeners' => [
+        Listener\UserLogoutListener::class,
+    ],
+    'service_manager' => [
+        'factories' => [
+            Listener\UserLogoutListener::class => Service\Listener\UserLogoutListenerFactory::class,
+            Session\TicketStorage::class => Service\Session\TicketStorageFactory::class,
         ],
     ],
     'entity_manager' => [
@@ -49,6 +59,17 @@ return [
                                 'action' => 'login',
                             ],
                         ],
+                    ],
+                    'slo' => [
+                        'type' => 'Literal',
+                        'options' => [
+                            'route' => '/slo',
+                            'defaults' => [
+                                'controller' => 'Slo',
+                                'action' => 'receive',
+                            ],
+                        ],
+                        'may_terminate' => true,
                     ],
                     'validate' => [
                         'type' => 'Literal',

--- a/src/Controller/SloController.php
+++ b/src/Controller/SloController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace CAS\Controller;
+
+use CAS\Session\TicketStorage;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\Session\Container;
+use Psr\Log\LoggerInterface;
+
+class SloController extends AbstractActionController
+{
+    private TicketStorage $ticketStorage;
+    private LoggerInterface $logger;
+
+    public function __construct(TicketStorage $ticketStorage, LoggerInterface $logger)
+    {
+        $this->ticketStorage = $ticketStorage;
+        $this->logger = $logger;
+    }
+
+    public function receiveAction()
+    {
+        $request = $this->getRequest();
+        if (!$request instanceof Request) {
+            return $this->acknowledge();
+        }
+
+        $logoutRequest = $this->extractLogoutRequest($request);
+        if ($logoutRequest === null) {
+            $this->logger->warning('CAS SLO request received without a logoutRequest payload.');
+            return $this->acknowledge();
+        }
+
+        $ticket = $this->extractSessionIndex($logoutRequest);
+        if ($ticket === null) {
+            $this->logger->warning('CAS SLO request received without a valid SessionIndex.');
+            return $this->acknowledge();
+        }
+
+        $sessionId = $this->ticketStorage->remove($ticket);
+        if ($sessionId === null) {
+            $this->logger->info(sprintf('CAS SLO for ticket "%s" received but no matching session was found.', $ticket));
+            return $this->acknowledge();
+        }
+
+        $sessionManager = Container::getDefaultManager();
+        $saveHandler = $sessionManager->getSaveHandler();
+
+        if ($saveHandler && method_exists($saveHandler, 'destroy')) {
+            $saveHandler->destroy($sessionId);
+        } else {
+            $sessionManager->destroy();
+        }
+
+        $this->logger->info(sprintf('CAS SLO destroyed session "%s" for ticket "%s".', $sessionId, $ticket));
+
+        return $this->acknowledge();
+    }
+
+    private function extractLogoutRequest(Request $request): ?string
+    {
+        $logoutRequest = $request->getPost('logoutRequest', null);
+        if ($logoutRequest) {
+            return (string) $logoutRequest;
+        }
+
+        $logoutRequest = $request->getQuery('logoutRequest', null);
+        if ($logoutRequest) {
+            return (string) $logoutRequest;
+        }
+
+        $content = $request->getContent();
+        return $content !== '' ? $content : null;
+    }
+
+    private function extractSessionIndex(string $payload): ?string
+    {
+        if ($payload === '') {
+            return null;
+        }
+
+        $previous = libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($payload);
+        if ($xml === false) {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+            return null;
+        }
+
+        $nodes = $xml->xpath('//*[local-name()="SessionIndex"]');
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if (!$nodes) {
+            return null;
+        }
+
+        $sessionIndex = trim((string) $nodes[0]);
+        return $sessionIndex !== '' ? $sessionIndex : null;
+    }
+
+    private function acknowledge(): Response
+    {
+        $response = $this->getResponse();
+        if (!$response instanceof Response) {
+            $response = new Response();
+        }
+
+        $response->setStatusCode(Response::STATUS_CODE_200);
+        $response->setContent('');
+        return $response;
+    }
+}
+

--- a/src/Entity/CasTicket.php
+++ b/src/Entity/CasTicket.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace CAS\Entity;
+
+use DateTimeImmutable;
+use Omeka\Entity\AbstractEntity;
+
+/**
+ * @Entity
+ * @Table(name="cas_ticket")
+ */
+class CasTicket extends AbstractEntity
+{
+    /**
+     * @Id
+     * @Column(type="string", length=255)
+     */
+    protected $ticket;
+
+    /**
+     * @Column(name="session_id", type="string", length=255)
+     */
+    protected $sessionId;
+
+    /**
+     * @Column(name="created_at", type="datetime")
+     */
+    protected $createdAt;
+
+    /**
+     * @Column(name="updated_at", type="datetime")
+     */
+    protected $updatedAt;
+
+    public function getTicket(): string
+    {
+        return $this->ticket;
+    }
+
+    public function getId()
+    {
+        return $this->ticket;
+    }
+
+    public function setTicket(string $ticket): void
+    {
+        $this->ticket = $ticket;
+    }
+
+    public function getSessionId(): string
+    {
+        return $this->sessionId;
+    }
+
+    public function setSessionId(string $sessionId): void
+    {
+        $this->sessionId = $sessionId;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -103,5 +103,31 @@ class ConfigForm extends Form
                 'required' => false,
             ],
         ]);
+
+        $this->add([
+            'type' => 'Checkbox',
+            'name' => 'global_logout',
+            'options' => [
+                'label' => 'Enable CAS global logout', // @translate
+                'info' => 'Redirect local logouts to CAS to terminate the global session.', // @translate
+            ],
+            'attributes' => [
+                'id' => 'global_logout',
+                'required' => false,
+            ],
+        ]);
+
+        $this->add([
+            'type' => 'Text',
+            'name' => 'logout_redirect_service',
+            'options' => [
+                'label' => 'Logout redirect service URL', // @translate
+                'info' => 'Optional URL the CAS server should redirect to after logout. Defaults to the Omeka S homepage.', // @translate
+            ],
+            'attributes' => [
+                'id' => 'logout_redirect_service',
+                'required' => false,
+            ],
+        ]);
     }
 }

--- a/src/Listener/UserLogoutListener.php
+++ b/src/Listener/UserLogoutListener.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace CAS\Listener;
+
+use CAS\Session\TicketStorage;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\EventManager\ListenerAggregateInterface;
+use Laminas\EventManager\ListenerAggregateTrait;
+use Laminas\Mvc\Controller\AbstractController;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Session\Container;
+use Omeka\Settings\Settings;
+use Psr\Container\ContainerInterface;
+
+class UserLogoutListener implements ListenerAggregateInterface
+{
+    use ListenerAggregateTrait;
+
+    private Settings $settings;
+    private TicketStorage $ticketStorage;
+    private ContainerInterface $services;
+    private ?AuthenticationService $authenticationService = null;
+
+    public function __construct(Settings $settings, TicketStorage $ticketStorage, ContainerInterface $services)
+    {
+        $this->settings = $settings;
+        $this->ticketStorage = $ticketStorage;
+        $this->services = $services;
+    }
+
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $sharedManager = $events->getSharedManager();
+        $this->listeners[] = $sharedManager->attach(AbstractController::class, MvcEvent::EVENT_DISPATCH, [$this, 'onDispatch'], 100);
+        $this->listeners[] = $sharedManager->attach('*', 'user.logout', [$this, 'onUserLogout'], 100);
+    }
+
+    public function onDispatch(MvcEvent $event)
+    {
+        $routeMatch = $event->getRouteMatch();
+        if (!$routeMatch) {
+            return;
+        }
+
+        $matchedRouteName = $routeMatch->getMatchedRouteName();
+        $action = $routeMatch->getParam('action');
+        if ($matchedRouteName !== 'logout' && $action !== 'logout') {
+            return;
+        }
+
+        if (!(bool) $this->settings->get('cas_global_logout')) {
+            return;
+        }
+
+        $casUrl = trim((string) $this->settings->get('cas_url'));
+        if ($casUrl === '') {
+            return;
+        }
+
+        $controller = $event->getTarget();
+        if (!$controller instanceof AbstractController) {
+            return;
+        }
+
+        $sessionManager = Container::getDefaultManager();
+        $sessionManager->start();
+
+        $this->getAuthenticationService()->clearIdentity();
+
+        $controller->getEventManager()->trigger('user.logout');
+        $sessionManager->destroy();
+
+        $logoutUrl = $this->buildLogoutUrl($controller, $casUrl);
+        $response = $controller->redirect()->toUrl($logoutUrl);
+
+        $event->setResult($response);
+        $event->stopPropagation(true);
+
+        return $response;
+    }
+
+    public function onUserLogout(EventInterface $event): void
+    {
+        $sessionManager = Container::getDefaultManager();
+        $sessionManager->start();
+
+        $sessionId = $sessionManager->getId();
+        if ($sessionId === '') {
+            return;
+        }
+
+        $this->ticketStorage->removeBySessionId($sessionId);
+
+        $sessionStorage = $sessionManager->getStorage();
+        if ($sessionStorage->offsetExists('cas_service_tickets')) {
+            $sessionStorage->offsetUnset('cas_service_tickets');
+        }
+    }
+
+    private function buildLogoutUrl(AbstractController $controller, string $casUrl): string
+    {
+        $casBaseUrl = rtrim($casUrl, '/');
+        $redirectService = trim((string) $this->settings->get('cas_logout_redirect_service'));
+
+        if ($redirectService === '') {
+            $redirectService = $controller->url()->fromRoute('top', [], ['force_canonical' => true]);
+        }
+
+        if ($redirectService === '') {
+            return $casBaseUrl . '/logout';
+        }
+
+        return sprintf('%s/logout?service=%s', $casBaseUrl, rawurlencode($redirectService));
+    }
+
+    private function getAuthenticationService(): AuthenticationService
+    {
+        if ($this->authenticationService === null) {
+            $this->authenticationService = $this->services->get('Omeka\AuthenticationService');
+        }
+
+        return $this->authenticationService;
+    }
+}
+

--- a/src/Service/Controller/LoginControllerFactory.php
+++ b/src/Service/Controller/LoginControllerFactory.php
@@ -21,8 +21,9 @@
 
 namespace CAS\Service\Controller;
 
-use Interop\Container\ContainerInterface;
 use CAS\Controller\LoginController;
+use CAS\Session\TicketStorage;
+use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class LoginControllerFactory implements FactoryInterface
@@ -32,7 +33,8 @@ class LoginControllerFactory implements FactoryInterface
         return new LoginController(
             $services->get('Omeka\HttpClient'),
             $services->get('Omeka\EntityManager'),
-            $services->get('Omeka\AuthenticationService')
+            $services->get('Omeka\AuthenticationService'),
+            $services->get(TicketStorage::class)
         );
     }
 }

--- a/src/Service/Controller/SloControllerFactory.php
+++ b/src/Service/Controller/SloControllerFactory.php
@@ -6,15 +6,17 @@ use CAS\Controller\SloController;
 use CAS\Session\TicketStorage;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\Log\PsrLoggerAdapter;
 
 class SloControllerFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
+        $laminasLogger = $services->get('Omeka\Logger');
+
         return new SloController(
             $services->get(TicketStorage::class),
-            $services->get('Omeka\Logger')
+            new PsrLoggerAdapter($laminasLogger)
         );
     }
 }
-

--- a/src/Service/Controller/SloControllerFactory.php
+++ b/src/Service/Controller/SloControllerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CAS\Service\Controller;
+
+use CAS\Controller\SloController;
+use CAS\Session\TicketStorage;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class SloControllerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new SloController(
+            $services->get(TicketStorage::class),
+            $services->get('Omeka\Logger')
+        );
+    }
+}
+

--- a/src/Service/Listener/UserLogoutListenerFactory.php
+++ b/src/Service/Listener/UserLogoutListenerFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CAS\Service\Listener;
+
+use CAS\Listener\UserLogoutListener;
+use CAS\Session\TicketStorage;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class UserLogoutListenerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new UserLogoutListener(
+            $services->get('Omeka\Settings'),
+            $services->get(TicketStorage::class),
+            $services
+        );
+    }
+}
+

--- a/src/Service/Session/TicketStorageFactory.php
+++ b/src/Service/Session/TicketStorageFactory.php
@@ -10,12 +10,8 @@ class TicketStorageFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
-        $tempDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
-        $basePath = defined('OMEKA_PATH') ? OMEKA_PATH : getcwd();
-        $namespace = md5((string) $basePath);
-        $storagePath = $tempDir . DIRECTORY_SEPARATOR . 'omeka_s_cas_' . $namespace . '.json';
-
-        return new TicketStorage($storagePath);
+        return new TicketStorage(
+            $services->get('Omeka\EntityManager')
+        );
     }
 }
-

--- a/src/Service/Session/TicketStorageFactory.php
+++ b/src/Service/Session/TicketStorageFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CAS\Service\Session;
+
+use CAS\Session\TicketStorage;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class TicketStorageFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $tempDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+        $basePath = defined('OMEKA_PATH') ? OMEKA_PATH : getcwd();
+        $namespace = md5((string) $basePath);
+        $storagePath = $tempDir . DIRECTORY_SEPARATOR . 'omeka_s_cas_' . $namespace . '.json';
+
+        return new TicketStorage($storagePath);
+    }
+}
+

--- a/src/Session/TicketStorage.php
+++ b/src/Session/TicketStorage.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace CAS\Session;
+
+class TicketStorage
+{
+    private string $storagePath;
+
+    public function __construct(string $storagePath)
+    {
+        $this->storagePath = $storagePath;
+    }
+
+    public function store(string $ticket, string $sessionId): void
+    {
+        if ($ticket === '' || $sessionId === '') {
+            return;
+        }
+
+        $this->write(function (array $map) use ($ticket, $sessionId) {
+            $map[$ticket] = $sessionId;
+            return $map;
+        });
+    }
+
+    public function getSessionId(string $ticket): ?string
+    {
+        $map = $this->read();
+        return $map[$ticket] ?? null;
+    }
+
+    public function remove(string $ticket): ?string
+    {
+        $removedSessionId = null;
+        $this->write(function (array $map) use ($ticket, &$removedSessionId) {
+            if (array_key_exists($ticket, $map)) {
+                $removedSessionId = $map[$ticket];
+                unset($map[$ticket]);
+            }
+            return $map;
+        });
+
+        return $removedSessionId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function removeBySessionId(string $sessionId): array
+    {
+        $removedTickets = [];
+        $this->write(function (array $map) use ($sessionId, &$removedTickets) {
+            foreach ($map as $ticket => $storedSessionId) {
+                if ($storedSessionId === $sessionId) {
+                    unset($map[$ticket]);
+                    $removedTickets[] = $ticket;
+                }
+            }
+            return $map;
+        });
+
+        return $removedTickets;
+    }
+
+    private function read(): array
+    {
+        if (!is_file($this->storagePath)) {
+            return [];
+        }
+
+        $handle = fopen($this->storagePath, 'rb');
+        if ($handle === false) {
+            return [];
+        }
+
+        try {
+            if (!flock($handle, LOCK_SH)) {
+                return [];
+            }
+
+            $content = stream_get_contents($handle);
+            flock($handle, LOCK_UN);
+        } finally {
+            fclose($handle);
+        }
+
+        $data = json_decode($content ?: '[]', true);
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param callable $writer fn(array $map): array
+     */
+    private function write(callable $writer): void
+    {
+        $directory = dirname($this->storagePath);
+        if (!is_dir($directory)) {
+            @mkdir($directory, 0777, true);
+        }
+
+        $handle = fopen($this->storagePath, 'c+b');
+        if ($handle === false) {
+            return;
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                return;
+            }
+
+            $existing = stream_get_contents($handle);
+            $map = json_decode($existing ?: '[]', true);
+            $map = is_array($map) ? $map : [];
+
+            $map = $writer($map);
+
+            ftruncate($handle, 0);
+            rewind($handle);
+            fwrite($handle, json_encode($map, JSON_UNESCAPED_SLASHES));
+            fflush($handle);
+
+            flock($handle, LOCK_UN);
+        } finally {
+            fclose($handle);
+        }
+    }
+}
+


### PR DESCRIPTION
# 🔐 CAS Global Logout Support

### **Shared Logout Listener**

* Added a shared logout listener that intercepts **Omeka’s logout actions**, clears the **local user identity**, prunes stored **CAS service tickets**, and optionally redirects through the **CAS `/logout` endpoint** with an **administrator-defined return service**.

### **Session–Ticket Mapping**

* Persisted **CAS service ticket ↔ PHP session mappings** during login.
* Introduced a **filesystem-backed `TicketStorage` service** to resolve sessions when the **CAS server issues back-channel Single Logout (SLO)** notifications.

### **SLO Controller Endpoint**

* Registered a new **`/cas/slo`** controller endpoint to accept **CAS 3.x logout payloads**.
* The endpoint:

  * Parses the `SessionIndex` from CAS logout XML or POST data.
  * Locates and destroys the mapped Omeka session.
  * Returns a `200 OK` acknowledgment and logs any anomalies for auditability.

### **Configuration Enhancements**

* Extended module configuration with:

  * `cas_global_logout` → enables or disables redirection to CAS global logout.
  * `cas_logout_redirect_service` → defines the service URL to redirect to after CAS logout.
* Exposed these options via the **admin configuration form**, and registered them through **service factories** so that all components are **container-managed** and consistent with Omeka S architecture.

---
