### PR TITLE
Allow to assign groups to created users, if module Group is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Allow to assign groups to created users, if module Group is enabled
+
 ## [0.6.3] - 2025-09-18
 
 - Redirect to / after login if user is not allowed to go to /admin

--- a/Module.php
+++ b/Module.php
@@ -92,6 +92,7 @@ class Module extends AbstractModule
             'user_name_attribute' => $settings->get('cas_user_name_attribute'),
             'user_email_attribute' => $settings->get('cas_user_email_attribute'),
             'show_login_link_in_user_bar' => $settings->get('cas_show_login_link_in_user_bar'),
+            'groups' => $settings->get('cas_groups'),
         ]);
 
         return $renderer->formCollection($form, false);
@@ -116,6 +117,10 @@ class Module extends AbstractModule
         $settings->set('cas_user_name_attribute', $formData['user_name_attribute']);
         $settings->set('cas_user_email_attribute', $formData['user_email_attribute']);
         $settings->set('cas_show_login_link_in_user_bar', $formData['show_login_link_in_user_bar']);
+
+        if (isset($formData['groups'])) {
+            $settings->set('cas_groups', $formData['groups']);
+        }
 
         return true;
     }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -17,8 +17,8 @@ return [
         ],
     ],
     'form_elements' => [
-        'invokables' => [
-            'CAS\Form\ConfigForm' => Form\ConfigForm::class,
+        'factories' => [
+            'CAS\Form\ConfigForm' => Service\Form\ConfigFormFactory::class,
         ],
     ],
     'js_translate_strings' => [

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -24,6 +24,7 @@ namespace CAS\Controller;
 use CAS\Entity\CasUser;
 use Doctrine\ORM\EntityManager;
 use Omeka\Entity\User;
+use Omeka\Module\Manager as ModuleManager;
 use Omeka\Permissions\Acl;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Http\Client as HttpClient;
@@ -36,12 +37,14 @@ class LoginController extends AbstractActionController
     protected $httpClient;
     protected $entityManager;
     protected $authenticationService;
+    protected ModuleManager $moduleManager;
 
-    public function __construct(HttpClient $httpClient, EntityManager $entityManager, AuthenticationService $authenticationService)
+    public function __construct(HttpClient $httpClient, EntityManager $entityManager, AuthenticationService $authenticationService, ModuleManager $moduleManager)
     {
         $this->httpClient = $httpClient;
         $this->entityManager = $entityManager;
         $this->authenticationService = $authenticationService;
+        $this->moduleManager = $moduleManager;
     }
 
     public function loginAction()
@@ -177,6 +180,10 @@ class LoginController extends AbstractActionController
 
                 $events->trigger('cas.user.create.pre', $user, $eventArgs);
 
+                if ($this->isModuleActive('Group')) {
+                    $this->assignGroupsToUser($user);
+                }
+
                 $em->persist($user);
                 $em->flush();
 
@@ -218,5 +225,30 @@ class LoginController extends AbstractActionController
     protected function getCasUrlSetting()
     {
         return trim($this->settings()->get('cas_url'));
+    }
+
+    protected function isModuleActive(string $moduleName): bool
+    {
+        if ($this->moduleManager->isRegistered($moduleName)) {
+            $module = $this->moduleManager->getModule($moduleName);
+
+            return $module->getState() === ModuleManager::STATE_ACTIVE;
+        }
+
+        return false;
+    }
+
+    protected function assignGroupsToUser(User $user): void
+    {
+        $groupIds = $this->settings()->get('cas_groups', []);
+        foreach ($groupIds as $groupId) {
+            $group = $this->entityManager->find('Group\Entity\Group', $groupId);
+            if ($group) {
+                $groupUser = new \Group\Entity\GroupUser($group, $user);
+                $this->entityManager->persist($groupUser);
+            } else {
+                $this->logger()->warn(sprintf('CAS: Failed to assign user to non-existing group #%d', $groupId));
+            }
+        }
     }
 }

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -22,9 +22,12 @@
 namespace CAS\Form;
 
 use Laminas\Form\Form;
+use Omeka\Module\Manager as ModuleManager;
 
 class ConfigForm extends Form
 {
+    protected ModuleManager $moduleManager;
+
     public function init()
     {
         $this->add([
@@ -92,6 +95,22 @@ class ConfigForm extends Form
             ],
         ]);
 
+        if ($this->isModuleActive('Group')) {
+            $this->add([
+                'name' => 'groups',
+                'type' => 'Group\Form\Element\GroupSelect',
+                'options' => [
+                    'label' => 'Groups', // @translate
+                    'info' => 'Created users will be in these groups', // @translate
+                ],
+                'attributes' => [
+                    'multiple' => true,
+                    'class' => 'chosen-select',
+                    'data-placeholder' => 'Select groups', // @translate
+                ],
+            ]);
+        }
+
         $this->add([
             'type' => 'Checkbox',
             'name' => 'show_login_link_in_user_bar',
@@ -103,5 +122,27 @@ class ConfigForm extends Form
                 'required' => false,
             ],
         ]);
+    }
+
+    public function setModuleManager(ModuleManager $moduleManager): void
+    {
+        $this->moduleManager = $moduleManager;
+    }
+
+    public function getModuleManager(): ModuleManager
+    {
+        return $this->moduleManager;
+    }
+
+    protected function isModuleActive(string $moduleName): bool
+    {
+        $moduleManager = $this->getModuleManager();
+        if ($moduleManager->isRegistered($moduleName)) {
+            $module = $moduleManager->getModule($moduleName);
+
+            return $module->getState() === ModuleManager::STATE_ACTIVE;
+        }
+
+        return false;
     }
 }

--- a/src/Service/Controller/LoginControllerFactory.php
+++ b/src/Service/Controller/LoginControllerFactory.php
@@ -32,7 +32,8 @@ class LoginControllerFactory implements FactoryInterface
         return new LoginController(
             $services->get('Omeka\HttpClient'),
             $services->get('Omeka\EntityManager'),
-            $services->get('Omeka\AuthenticationService')
+            $services->get('Omeka\AuthenticationService'),
+            $services->get('Omeka\ModuleManager')
         );
     }
 }

--- a/src/Service/Form/ConfigFormFactory.php
+++ b/src/Service/Form/ConfigFormFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CAS\Service\Form;
+
+use CAS\Form\ConfigForm;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ConfigFormFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $form = new ConfigForm(null, $options ?? []);
+
+        $form->setModuleManager($services->get('Omeka\ModuleManager'));
+
+        return $form;
+    }
+}


### PR DESCRIPTION
Test plan:

1. Install Group
2. Create some groups
3. Go to the CAS module configuration page and select some groups
4. Log in with CAS with a user that does not exist in Omeka yet
5. Verify that the created user belongs to the groups you selected